### PR TITLE
error handling on processing incoming form

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -7,6 +7,11 @@ function parse(opts) {
   Object.assign(form, opts);
 
   return (req, res, next) => {
+    form.on('error', (err) => {
+      next(err);
+      return;
+    });
+
     form.parse(req, (err, fields, files) => {
       if (err) {
         next(err);


### PR DESCRIPTION
We were getting errors at "formidable/lib/incoming_form.js", resulting in an uncaught exception. I added form.on('error', callback) to handle these types of errors.
