### PR TITLE
Fix error from simultaneous requests.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,10 +3,10 @@
 const formidable = require('formidable');
 
 function parse(opts) {
-  const form = new formidable.IncomingForm();
-  Object.assign(form, opts);
-
   return (req, res, next) => {
+    const form = new formidable.IncomingForm();
+    Object.assign(form, opts);
+
     form.parse(req, (err, fields, files) => {
       if (err) {
         next(err);


### PR DESCRIPTION
Was getting a "Can't set headers after they are sent" error when receiving 2 simultaneous multipart/form-data requests.
Creating a new formidable.IncomingForm() per request fixed it.