### PR TITLE
Don't reuse IncomingForm for multiple requests

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,10 +3,10 @@
 const formidable = require('formidable');
 
 function parse(opts) {
-  const form = new formidable.IncomingForm();
-  Object.assign(form, opts);
-
   return (req, res, next) => {
+    const form = new formidable.IncomingForm();
+    Object.assign(form, opts);
+
     form.parse(req, (err, fields, files) => {
       if (err) {
         next(err);


### PR DESCRIPTION
IncomingForm docs show its use as a per request object. When used on multiple requests, each time that `parse` is called the callback is called as many times as parse has been called in the past. This creates issues as `next` can be called multiple times (which gets us into unexpected behavior town)